### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/evarga/idp-career/security/code-scanning/1](https://github.com/evarga/idp-career/security/code-scanning/1)

To fix this, explicitly declare least-privilege `GITHUB_TOKEN` permissions for the workflow. This workflow only checks out code and runs pylint; it does not need to write to the repository or modify issues/PRs. The best fix is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs that do not override it. Set `contents: read` as a minimal, safe starting point that matches CodeQL’s recommendation and supports `actions/checkout`. No imports or additional methods are needed, since this is a YAML configuration change only. Concretely, in `.github/workflows/pylint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` declaration and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
